### PR TITLE
Update type codes

### DIFF
--- a/input/fsh/instance/mtp1.fsh
+++ b/input/fsh/instance/mtp1.fsh
@@ -30,8 +30,8 @@ Usage: #inline
 * identifier.system = "urn:ietf:rfc:3986"
 * identifier.value = "urn:uuid:24c84eef-f9db-4710-8f6c-2d342ad3ac2d"
 * status = #final
-* type.coding[0] = $lnc#77603-9 "Medication treatment plan.extended Document"
-* type.coding[+] = $sct#419891008 "Record artifact (record artifact)"
+* type.coding[+] = $sct#761931002 "Medication treatment plan report (record artifact)"
+* type.coding[+] = $lnc#77603-9 "Medication treatment plan.extended Document"
 * subject.reference = "urn:uuid:2dbfe659-07d0-45c7-b8df-4a48372049a3"
 * date = "2023-04-11T12:00:00+02:00"
 * author[person].reference = "urn:uuid:213d609a-1164-459a-bb10-727516ae3d0c"

--- a/input/fsh/instance/pmlc1.fsh
+++ b/input/fsh/instance/pmlc1.fsh
@@ -26,7 +26,7 @@ Usage: #inline
 * identifier.system = "urn:ietf:rfc:3986"
 * identifier.value = "urn:uuid:cdce5856-7ef7-4f0c-a456-45531110aeb5"
 * status = #final
-* type = $sct#721912009 "Medication summary document (record artifact)"
+* type = $sct#736378000 "Medication management plan (record artifact)"
 * subject = Reference(urn:uuid:574d95b5-6ee1-4726-b399-e16eaf225e60)
 * date = "2023-04-21T08:47:22+02:00"
 * author = Reference(urn:uuid:a7082159-24c8-4991-97ae-ffee0c3e3ce8)


### PR DESCRIPTION
For Composition.type in eMed documents, the primary code is now the SNOMED CT one.
The LOINC code becomes optional.
The following SNOMED CT code changes happen:
- For MTP documents: `761931002` _Medication treatment plan report (record artifact)_
- For DIS documents: `294121000195110` _Medication dispense document (record artifact)_
- For PMLC documents: `736378000` _Medication management plan (record artifact)_